### PR TITLE
add configuration option for priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
 					],
 					"default": "right",
 					"description": "Specifies the alignment of the highlight counter in the status bar"
+				},
+				"highlight-counter.priority": {
+					"type": "integer",
+					"default": 100,
+					"description": "Specifies the priority of the highlight counter in the status bar. Higher values mean it should be shown more to the left."
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,14 @@
 import { window, workspace, StatusBarAlignment, StatusBarItem } from 'vscode';
 
 let alignment: number;
+let priority: number;
 let msg: StatusBarItem;
 
 workspace.onDidChangeConfiguration((event) => {
-    if (event.affectsConfiguration('highlight-counter.alignment')) {
+    if (
+        event.affectsConfiguration('highlight-counter.alignment') ||
+        event.affectsConfiguration('highlight-counter.priority')
+    ) {
         // Reactivate the extension to apply the new configuration
         deactivate();
         activate();
@@ -13,7 +17,8 @@ workspace.onDidChangeConfiguration((event) => {
 
 export function activate() {
     alignment = getAlignmentValue();
-    msg = window.createStatusBarItem(alignment, 100);
+    priority = getPriorityValue();
+    msg = window.createStatusBarItem(alignment, priority);
 
     window.onDidChangeTextEditorSelection(() => {
         let editor = window.activeTextEditor;
@@ -21,7 +26,7 @@ export function activate() {
         if (editor !== undefined) {
             let text = editor.document.getText(editor.selection);
 
-            if (text.length >= 1) {
+            if (text.length >= 1 && text.indexOf('\n') === -1) {
                 let matches = editor.document.getText().match(new RegExp(text, 'g'));
 
                 if (matches !== null && matches.length >= 1) {
@@ -50,5 +55,16 @@ export function deactivate() {
 function getAlignmentValue(): number {
     let alignment: string | undefined = workspace.getConfiguration('highlight-counter').get('alignment');
 
-    return alignment === StatusBarAlignment[StatusBarAlignment.Left].toLowerCase() ? StatusBarAlignment.Left : StatusBarAlignment.Right;
+    return alignment === StatusBarAlignment[StatusBarAlignment.Left].toLowerCase()
+        ? StatusBarAlignment.Left
+        : StatusBarAlignment.Right;
+}
+
+/**
+ * Get the configured priority value.
+ */
+function getPriorityValue(): number {
+    let priority: number | undefined = workspace.getConfiguration('highlight-counter').get('priority');
+
+    return Number(priority);
 }


### PR DESCRIPTION
hello @ramonbakker-rambit! I recently came across this extension after starting to write my own to do the same thing. this one works great, but I'd like to be able to configure the status bar item's priority in addition to its alignment.

this PR adds a configuration option for priority, defaulting to the value it currently uses (100). I also made it ignore selections that include a newline, as this is more consistent with Code's built-in highlight behavior.