### PR TITLE
Add support for highlight counting with backslashes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ export function activate() {
             let text = editor.document.getText(editor.selection);
 
             if (text.length >= 1 && text.indexOf('\n') === -1) {
+                text = text.replace('\\', '\\\\');
                 let matches = editor.document.getText().match(new RegExp(text, 'g'));
 
                 if (matches !== null && matches.length >= 1) {


### PR DESCRIPTION
In the current implementation the backslash will result in the escaping of the character in the RexExp, which will result in an invalid or no highlighted count. This PR adds a simple replace that will escape those backslashes.    