### PR TITLE
Fix regex escape bug, add whole word matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "highlight-counter" extension will be documented in this file.
 
+## Unreleased
+
+### Added
+
+-   Option to enable whole word matching and configuration for word separators.
+
+### Fixed
+
+-   Highlight counting of selections which contain regular expression special characters.
+
 ## [1.5.1] - 19-08-2019
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -46,6 +46,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Enables case sensitivity."
+                },
+                "highlight-counter.wholeWordMatching": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enables whole word matching."
+                },
+                "highlight-counter.wordSeparators": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Custom word separators for whole word matching. If not specified. the value of \"editor.wordSeparators\" will be used."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
                 "highlight-counter.wordSeparators": {
                     "type": "string",
                     "default": "",
-                    "description": "Custom word separators for whole word matching. If not specified. the value of \"editor.wordSeparators\" will be used."
+                    "description": "Custom word separators for whole word matching. If not specified, the value of \"editor.wordSeparators\" will be used."
                 }
             }
         }


### PR DESCRIPTION
Hello! Thanks for writing this extension. Three years ago I switched from Atom to VSCode and really missed the "highlight count"  feature from the [highlight-selected](https://atom.io/packages/highlight-selected) Atom extension. There was even [an issue asking for this functionality for VSCode](https://github.com/microsoft/vscode/issues/19208). I've always wanted to write my own extension to do this since I did not find one that works. Until recently I've finally learned how to write a VSCode extension but just found your extension works :)

This PR brings some improvements: 

1. Properly escape regular expression special characters

In the current implementation the selected text is used as a regular expression for matching, but only the backslash character is escaped (#3). However in fact all regular expression special characters need to be escaped for converting any literal string to be used as a regular expression. To reproduce the bug, just write `hello world ...` in an editor tab and select `...`. It says `Highlighted: 5` instead of `Highlighted: 1`. This PR will fix this. Reference: [MDN: Javascript Guide: Regular Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping). 

2. Add option to enable whole word matching

It would be good to have an option to perform whole word matching. This could be handy when trying to find unused identifiers in the source code. This is also the default behavior of that Atom extension. I'm adding an option to perform whole word matching, which is `false` by default to avoid disrupting current users of your extension. The word separator characters (word boundary) can also be configured.